### PR TITLE
게시판 pai 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/fastcampus-board/build.gradle
+++ b/fastcampus-board/build.gradle
@@ -24,13 +24,16 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
 }
 
 tasks.named('test') {

--- a/fastcampus-board/src/main/java/com/fastcampus/board/repository/ArticleCommentRepository.java
+++ b/fastcampus-board/src/main/java/com/fastcampus/board/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.board.repository;
 
 import com.fastcampus.board.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/fastcampus-board/src/main/java/com/fastcampus/board/repository/ArticleRepository.java
+++ b/fastcampus-board/src/main/java/com/fastcampus/board/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.board.repository;
 
 import com.fastcampus.board.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/fastcampus-board/src/test/java/com/fastcampus/board/Controller/DataRestTest.java
+++ b/fastcampus-board/src/test/java/com/fastcampus/board/Controller/DataRestTest.java
@@ -1,0 +1,88 @@
+package com.fastcampus.board.Controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+// 이 내용은 integration 테스트이므로 이 API가 실행한 결과가 리포지토리까지 저부 다 실행을 시켜서
+// Hibernat Query 문까지 나온다. 어떻게 보면 DB에 영향을 주는 테스트가 되어버림.
+//Transactional 을 넣어줌 테스트에서 동작하는 transactional의 기본 동작은 rollback 이다.
+// 모든 Data List 테스트 밑에 각각의 유닛 테스트 메소드들은 롤백상태로 트랜잭션이 묶이게 된다.
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc){
+        this.mvc = mvc;
+
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void  givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        //Given
+
+        //When&Then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void  givenNothing_whenRequestingArticles_thenReturnsArticleJsonResponse() throws Exception {
+        //Given
+
+        //When&Then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void  givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        //Given
+
+        //When&Then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void  givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        //Given
+
+        //When&Then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void  givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        //Given
+
+        //When&Then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data  REST 로 서비스 하고, 해당 api 들의 존재 여부만 체크 하게끔 통합테스트 작